### PR TITLE
Update packages to their latest release.

### DIFF
--- a/src/Amido.Stacks.API.Tests/Amido.Stacks.API.Tests.csproj
+++ b/src/Amido.Stacks.API.Tests/Amido.Stacks.API.Tests.csproj
@@ -13,19 +13,19 @@
 		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
 		<PackageReference Include="FluentAssertions" Version="6.12.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.24" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-		<PackageReference Include="Serilog" Version="3.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+		<PackageReference Include="Serilog" Version="3.1.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
 		<PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
 		<PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
 		<PackageReference Include="Serilog.Sinks.InMemory.Assertions" Version="0.11.0" />
 		<PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
-		<PackageReference Include="xunit" Version="2.4.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+		<PackageReference Include="xunit" Version="2.6.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.2.0">
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/src/Amido.Stacks.API.Tests/Amido.Stacks.API.Tests.csproj
+++ b/src/Amido.Stacks.API.Tests/Amido.Stacks.API.Tests.csproj
@@ -1,0 +1,38 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AutoFixture" Version="4.18.0" />
+		<PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+		<PackageReference Include="FluentAssertions" Version="6.12.0" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.24" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+		<PackageReference Include="Serilog" Version="3.0.1" />
+		<PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+		<PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
+		<PackageReference Include="Serilog.Sinks.InMemory" Version="0.11.0" />
+		<PackageReference Include="Serilog.Sinks.InMemory.Assertions" Version="0.11.0" />
+		<PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.2.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\Amido.Stacks.API\Amido.Stacks.API.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/CorrelationIdMiddlewareTestSteps.cs
+++ b/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/CorrelationIdMiddlewareTestSteps.cs
@@ -1,0 +1,233 @@
+using Amido.Stacks.API.Configuration;
+using Amido.Stacks.API.Middleware;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Serilog;
+using Serilog.Sinks.InMemory;
+using Serilog.Sinks.InMemory.Assertions;
+
+namespace Amido.Stacks.API.Tests.IntegrationTests.Middleware;
+
+public class CorrelationIdMiddlewareTestSteps
+{
+    private readonly Dictionary<string, string> _configurationCollection;
+    private const string CONFIGURATION_COLLECTION_SECTION_NAME = "CorrelationId";
+
+    private readonly IHostBuilder _hostBuilder;
+    private IHeaderDictionary _requestHeaders;
+    private HttpContext _responseMessage;
+    private InMemorySink _inMemoryLoggingSink;
+    private bool _willSerilogEnrichLogsWithCorrelationId;
+
+
+    public CorrelationIdMiddlewareTestSteps()
+    {
+        _configurationCollection = new Dictionary<string, string>();
+        _hostBuilder = createHostBuilder();
+        _requestHeaders = new HeaderDictionary();
+        _inMemoryLoggingSink = new InMemorySink();
+        _responseMessage = new DefaultHttpContext();
+        _willSerilogEnrichLogsWithCorrelationId = false;
+    }
+
+
+    //
+    //  Given
+    //
+
+    public void GivenTheConfigurationFileHasTheHeaderNameSetTo(string headerName)
+    {
+        _configurationCollection.Add($"{CONFIGURATION_COLLECTION_SECTION_NAME}:HeaderName", headerName);
+    }
+
+
+    public void GivenTheConfigurationFileDoesNotHaveTheHeaderNameSet()
+    {
+        _configurationCollection.Remove($"{CONFIGURATION_COLLECTION_SECTION_NAME}:HeaderName");
+    }
+
+
+    public void GivenTheConfigurationFileHasIncludeInResponseSetTo(bool includeInResponse)
+    {
+        _configurationCollection.Add($"{CONFIGURATION_COLLECTION_SECTION_NAME}:IncludeInResponse", includeInResponse.ToString());
+    }
+
+
+    public void GivenTheRequestHeaderHasAlreadyBeenSet(string headerName, string headerValue)
+    {
+        _requestHeaders = new HeaderDictionary(new Dictionary<string, StringValues>
+        {
+            { headerName, headerValue }
+        });
+    }
+
+
+    public void GivenTheRequestHeaderHasNotAlreadyBeenSet()
+    {
+        _requestHeaders = new HeaderDictionary();
+    }
+
+
+    public void GivenSerilogIsConfiguredToEnrichLogsWithCorrelationId()
+    {
+        _willSerilogEnrichLogsWithCorrelationId = true;
+        _hostBuilder.ConfigureServices(s => s.AddHttpContextAccessor());
+    }
+
+
+    //
+    //  When
+    //
+
+    public async void WhenRequestIsSentToTheServer()
+    {
+        initializeInMemoryLogger();
+
+        var host = await _hostBuilder.StartAsync();
+        var testServer = host.GetTestServer();
+
+        _responseMessage = await testServer.SendAsync(c =>
+        {
+            c.Request.Method = HttpMethods.Get;
+            c.Request.Path = "/";
+            foreach (var header in _requestHeaders)
+            {
+                c.Request.Headers.Add(header);
+            }
+        });
+
+        _inMemoryLoggingSink = InMemorySink.Instance;
+    }
+
+
+    //
+    //  Then
+    //
+
+    public void ThenRequestHeaderIsAddedWithTheName(string headerName)
+    {
+        _responseMessage.Request.Headers.ContainsKey(headerName).Should().BeTrue();
+        _responseMessage.Request.Headers[headerName].ToString().Should().NotBeEmpty();
+    }
+
+
+    public void ThenRequestHeaderIsAddedWithTheNameAndValue(string headerName, string headerValue)
+    {
+        _responseMessage.Request.Headers.ContainsKey(headerName).Should().BeTrue();
+        _responseMessage.Request.Headers[headerName].ToString().Should().Be(headerValue);
+    }
+
+
+    public void ThenRequestHeaderIsNotAddedWithTheName(string headerName)
+    {
+        _responseMessage.Request.Headers.ContainsKey(headerName).Should().BeFalse();
+    }
+
+
+    public void ThenResponseHeaderIsAddedWithTheName(string headerName)
+    {
+        _responseMessage.Response.Headers.ContainsKey(headerName).Should().BeTrue();
+    }
+
+
+    public void ThenResponseHeaderIsAddedWithTheNameAndValue(string headerName, string headerValue)
+    {
+        _responseMessage.Response.Headers.ContainsKey(headerName).Should().BeTrue();
+        _responseMessage.Request.Headers[headerName].ToString().Should().Be(headerValue);
+    }
+
+
+    public void ThenResponseHeaderIsNotAddedWithTheName(string headerName)
+    {
+        _responseMessage.Response.Headers.ContainsKey(headerName).Should().BeFalse();
+    }
+
+
+    public void ThenLogsIncludePropertyWithTheName(string propertyName)
+    {
+        _inMemoryLoggingSink.Should().HaveMessage(LoggingMiddleware.MiddlewareStartingLogMessage)
+                            .Appearing().Once()
+                            .WithProperty(propertyName);
+
+        _inMemoryLoggingSink.Should().HaveMessage(LoggingMiddleware.MiddlewareCompleteLogMessage)
+                            .Appearing().Once()
+                            .WithProperty(propertyName);
+    }
+
+
+    public void ThenLogsIncludePropertyWithTheNameAndValue(string headerName, string headerValue)
+    {
+        _inMemoryLoggingSink.Should().HaveMessage(LoggingMiddleware.MiddlewareStartingLogMessage)
+                            .Appearing().Once()
+                            .WithProperty(headerName)
+                            .WithValue(headerValue);
+
+        _inMemoryLoggingSink.Should().HaveMessage(LoggingMiddleware.MiddlewareCompleteLogMessage)
+                            .Appearing().Once()
+                            .WithProperty(headerName)
+                            .WithValue(headerValue);
+    }
+
+
+    //
+    //  Setup
+    //
+
+    private void initializeInMemoryLogger()
+    {
+        if (_willSerilogEnrichLogsWithCorrelationId)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .WriteTo.InMemory()
+                .Enrich.FromLogContext()
+                .Enrich.WithCorrelationId()
+                .CreateLogger();
+        }
+        else
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .WriteTo.InMemory()
+                .Enrich.FromLogContext()
+                .CreateLogger();
+        }
+    }
+
+
+    private IHostBuilder createHostBuilder()
+    {
+        return new HostBuilder().ConfigureWebHost(webBuilder =>
+        {
+            webBuilder.UseTestServer()
+                      .Configure(app =>
+                      {
+                          app.UseMiddleware<CorrelationIdMiddleware>();
+                          app.UseMiddleware<LoggingMiddleware>();
+                      })
+                      .ConfigureAppConfiguration((_, configBuilder) =>
+                      {
+                          configBuilder.AddInMemoryCollection(_configurationCollection);
+                      })
+                      .ConfigureLogging((_, builder) =>
+                      {
+                          builder.ClearProviders();
+                          builder.AddSerilog();
+                      })
+                      .ConfigureServices((hostContext, services) =>
+                      {
+                          services.AddOptions();
+                          services.AddLogging();
+                          var correlationIdSection = hostContext.Configuration.GetSection(CONFIGURATION_COLLECTION_SECTION_NAME);
+                          services.Configure<CorrelationIdConfiguration>(correlationIdSection);
+                      });
+        });
+    }
+}

--- a/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/CorrelationIdMiddlewareTestStories.cs
+++ b/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/CorrelationIdMiddlewareTestStories.cs
@@ -100,7 +100,9 @@ public class CorrelationIdMiddlewareTestStories
     [Theory, AutoData]
     public void CorrelationIdLogContextPropertyIsNotNullWhenAddedOnlyOnce(CorrelationIdMiddlewareTestSteps steps)
     {
-        //  Added to test issue where Correlation ID has NULL value:  See Line 26 of CorrelationIdMiddleware.cs
+        //  A previous issue in .Net Core 2.1 replaced the Correlation ID with a NULL value.
+        //  The work around fr this issue has been removed as that issue cannot be reproduced.
+        //  This test is in place to ensure it doesn't re-occur.
         this.Given(_   => steps.GivenTheConfigurationFileDoesNotHaveTheHeaderNameSet())
                 .And(_ => steps.GivenSerilogIsConfiguredToEnrichLogsWithCorrelationId())
             .When(_    => steps.WhenRequestIsSentToTheServer())

--- a/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/CorrelationIdMiddlewareTestStories.cs
+++ b/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/CorrelationIdMiddlewareTestStories.cs
@@ -1,0 +1,112 @@
+namespace Amido.Stacks.API.Tests.IntegrationTests.Middleware;
+
+public class CorrelationIdMiddlewareTestStories
+{
+    private const string DEFAULT_HEADER_NAME = "x-correlation-id";
+    private const string CUSTOM_HEADER_NAME = "x-custom-correlation-id";
+    private const string PRESET_HEADER_VALUE = "already-set";
+    private const string CORRELATION_ID_LOG_CONTEXT_PROPERTY = "CorrelationId";
+
+
+    [Theory, AutoData]
+    public void MiddlewareAddsRequestHeaderWhenOneHasNotYetBeenSet(CorrelationIdMiddlewareTestSteps steps)
+    {
+        this.Given(_   => steps.GivenTheConfigurationFileDoesNotHaveTheHeaderNameSet())
+                .And(_ => steps.GivenTheConfigurationFileHasIncludeInResponseSetTo(false))
+                .And(_ => steps.GivenTheRequestHeaderHasNotAlreadyBeenSet())
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenResponseHeaderIsNotAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheName(DEFAULT_HEADER_NAME))
+            .BDDfy();
+    }
+
+
+    [Theory, AutoData]
+    public void MiddlewareAddsRequestHeaderWhenOneHasNotYetBeenSetUsingConfigurationName(CorrelationIdMiddlewareTestSteps steps)
+    {
+        this.Given(_   => steps.GivenTheConfigurationFileHasTheHeaderNameSetTo(CUSTOM_HEADER_NAME))
+                .And(_ => steps.GivenTheConfigurationFileHasIncludeInResponseSetTo(false))
+                .And(_ => steps.GivenTheRequestHeaderHasNotAlreadyBeenSet())
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheName(CUSTOM_HEADER_NAME))
+                .And(_ => steps.ThenRequestHeaderIsNotAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenResponseHeaderIsNotAddedWithTheName(CUSTOM_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheName(CUSTOM_HEADER_NAME))
+            .BDDfy();
+    }
+
+
+    [Theory, AutoData]
+    public void MiddlewareAddsResponseHeaderWhenConfiguredToInclude(CorrelationIdMiddlewareTestSteps steps)
+    {
+        this.Given(_   => steps.GivenTheConfigurationFileDoesNotHaveTheHeaderNameSet())
+                .And(_ => steps.GivenTheConfigurationFileHasIncludeInResponseSetTo(true))
+                .And(_ => steps.GivenTheRequestHeaderHasNotAlreadyBeenSet())
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenResponseHeaderIsAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheName(DEFAULT_HEADER_NAME))
+            .BDDfy();
+    }
+
+
+    [Theory, AutoData]
+    public void MiddlewareAddsResponseHeaderWhenConfiguredToIncludeUsingConfigurationName(CorrelationIdMiddlewareTestSteps steps)
+    {
+        this.Given(_   => steps.GivenTheConfigurationFileHasTheHeaderNameSetTo(CUSTOM_HEADER_NAME))
+                .And(_ => steps.GivenTheConfigurationFileHasIncludeInResponseSetTo(true))
+                .And(_ => steps.GivenTheRequestHeaderHasNotAlreadyBeenSet())
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheName(CUSTOM_HEADER_NAME))
+                .And(_ => steps.ThenRequestHeaderIsNotAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenResponseHeaderIsAddedWithTheName(CUSTOM_HEADER_NAME))
+                .And(_ => steps.ThenResponseHeaderIsNotAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheName(CUSTOM_HEADER_NAME))
+            .BDDfy();
+    }
+
+
+    [Theory, AutoData]
+    public void MiddlewareDoesNotAdjustRequestHeaderWhenOneHasNotAlreadyBeenSet(CorrelationIdMiddlewareTestSteps steps)
+    {
+        this.Given(_   => steps.GivenTheConfigurationFileDoesNotHaveTheHeaderNameSet())
+                .And(_ => steps.GivenTheConfigurationFileHasIncludeInResponseSetTo(true))
+                .And(_ => steps.GivenTheRequestHeaderHasAlreadyBeenSet(DEFAULT_HEADER_NAME, PRESET_HEADER_VALUE))
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheNameAndValue(DEFAULT_HEADER_NAME, PRESET_HEADER_VALUE))
+                .And(_ => steps.ThenResponseHeaderIsAddedWithTheNameAndValue(DEFAULT_HEADER_NAME, PRESET_HEADER_VALUE))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheNameAndValue(DEFAULT_HEADER_NAME, PRESET_HEADER_VALUE))
+            .BDDfy();
+    }
+
+
+    [Theory, AutoData]
+    public void MiddlewareDoesNotAdjustRequestHeaderWithConfiguredNameWhenOneHasNotAlreadyBeenSet(CorrelationIdMiddlewareTestSteps steps)
+    {
+        this.Given(_   => steps.GivenTheConfigurationFileHasTheHeaderNameSetTo(CUSTOM_HEADER_NAME))
+            .And(_ => steps.GivenTheConfigurationFileHasIncludeInResponseSetTo(true))
+                .And(_ => steps.GivenTheRequestHeaderHasAlreadyBeenSet(CUSTOM_HEADER_NAME, PRESET_HEADER_VALUE))
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheNameAndValue(CUSTOM_HEADER_NAME, PRESET_HEADER_VALUE))
+                .And(_ => steps.ThenRequestHeaderIsNotAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenResponseHeaderIsAddedWithTheNameAndValue(CUSTOM_HEADER_NAME, PRESET_HEADER_VALUE))
+                .And(_ => steps.ThenResponseHeaderIsNotAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheNameAndValue(CUSTOM_HEADER_NAME, PRESET_HEADER_VALUE))
+            .BDDfy();
+    }
+
+
+    [Theory, AutoData]
+    public void CorrelationIdLogContextPropertyIsNotNullWhenAddedOnlyOnce(CorrelationIdMiddlewareTestSteps steps)
+    {
+        //  Added to test issue where Correlation ID has NULL value:  See Line 26 of CorrelationIdMiddleware.cs
+        this.Given(_   => steps.GivenTheConfigurationFileDoesNotHaveTheHeaderNameSet())
+                .And(_ => steps.GivenSerilogIsConfiguredToEnrichLogsWithCorrelationId())
+            .When(_    => steps.WhenRequestIsSentToTheServer())
+            .Then(_    => steps.ThenRequestHeaderIsAddedWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheName(DEFAULT_HEADER_NAME))
+                .And(_ => steps.ThenLogsIncludePropertyWithTheName(CORRELATION_ID_LOG_CONTEXT_PROPERTY))
+            .BDDfy();
+    }
+}

--- a/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/LoggingMiddleware.cs
+++ b/src/Amido.Stacks.API.Tests/IntegrationTests/Middleware/LoggingMiddleware.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Amido.Stacks.API.Tests.IntegrationTests.Middleware;
+
+/// <summary>
+/// Middleware intended to be called after the Correlation ID Middleware when testing.
+/// This middleware writes logs that are checked to ensure that the Correlation ID
+/// property has been included.
+/// </summary>
+public class LoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILoggerFactory _loggerFactory;
+
+
+    public LoggingMiddleware(RequestDelegate next, ILoggerFactory loggerFactory)
+    {
+        _next = next;
+        _loggerFactory = loggerFactory;
+
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        var logger = _loggerFactory.CreateLogger(nameof(LoggingMiddleware));
+
+        logger.LogInformation(MiddlewareStartingLogMessage);
+        await _next(context);
+        logger.LogInformation(MiddlewareCompleteLogMessage);
+    }
+
+
+    public static string MiddlewareStartingLogMessage = "Inner middleware starting.";
+    public static string MiddlewareCompleteLogMessage = "Inner middleware complete.";
+}

--- a/src/Amido.Stacks.API.Tests/Usings.cs
+++ b/src/Amido.Stacks.API.Tests/Usings.cs
@@ -1,0 +1,4 @@
+global using AutoFixture.Xunit2;
+global using FluentAssertions;
+global using TestStack.BDDfy;
+global using Xunit;

--- a/src/Amido.Stacks.API.sln
+++ b/src/Amido.Stacks.API.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34031.279
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A122EAED-1BEA-4171-8B57-0DCB8FA0B769}"
 	ProjectSection(SolutionItems) = preProject
@@ -8,6 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Amido.Stacks.API", "Amido.Stacks.API\Amido.Stacks.API.csproj", "{78EA9F72-72DA-4F0C-A647-B315CF9DBD72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Amido.Stacks.API.Tests", "Amido.Stacks.API.Tests\Amido.Stacks.API.Tests.csproj", "{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +33,18 @@ Global
 		{78EA9F72-72DA-4F0C-A647-B315CF9DBD72}.Release|x64.Build.0 = Release|Any CPU
 		{78EA9F72-72DA-4F0C-A647-B315CF9DBD72}.Release|x86.ActiveCfg = Release|Any CPU
 		{78EA9F72-72DA-4F0C-A647-B315CF9DBD72}.Release|x86.Build.0 = Release|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Debug|x64.Build.0 = Debug|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Debug|x86.Build.0 = Debug|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Release|x64.ActiveCfg = Release|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Release|x64.Build.0 = Release|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Release|x86.ActiveCfg = Release|Any CPU
+		{F4B072C7-1AF9-4ADE-A055-7C0E4257035C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Amido.Stacks.API/Amido.Stacks.API.csproj
+++ b/src/Amido.Stacks.API/Amido.Stacks.API.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Serilog" Version="3.0.1" />
+    <PackageReference Include="Serilog" Version="3.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>

--- a/src/Amido.Stacks.API/Amido.Stacks.API.csproj
+++ b/src/Amido.Stacks.API/Amido.Stacks.API.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Description>API package for common features used throughout the projects.</Description>
     <Company>Amido</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -11,11 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Amido.Stacks.API/Amido.Stacks.API.csproj
+++ b/src/Amido.Stacks.API/Amido.Stacks.API.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Core" Version="0.2.19" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
+    <PackageReference Include="Serilog" Version="3.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />

--- a/src/Amido.Stacks.API/Amido.Stacks.API.csproj
+++ b/src/Amido.Stacks.API/Amido.Stacks.API.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Core" Version="0.2.21" />
+    <PackageReference Include="Amido.Stacks.Core" Version="0.2.35" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog" Version="3.1.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/src/Amido.Stacks.API/Middleware/CorrelationIdMiddleware.cs
+++ b/src/Amido.Stacks.API/Middleware/CorrelationIdMiddleware.cs
@@ -23,8 +23,6 @@ namespace Amido.Stacks.API.Middleware
         {
             var correlationId = GetOrSetCorrelationId(context);
 
-            //There is a bug in .Net Core 2.1+ that replaces CorrelationId by null, until fixed we will add attributes "twice"
-            using (LogContext.PushProperty("CorrelationId", correlationId.ToString()))
             using (LogContext.PushProperty(_options.HeaderName, correlationId.ToString()))
             {
                 await _next(context);


### PR DESCRIPTION
Update packages to their latest release.

####📲 What

Updating packages to their latest release. In this case, the dependency on Amido.Stacks.Core has been updated from v.02.19 to 0.2.35.  The obsolete references to Microsoft.AspNetCore.Diagnostics and Microsoft.AspNetCore.Mvc.Core have also been removed and replaced with a Framework Reference to Microsoft.AspNetCore.App as advised in the [migration guide](https://learn.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-3.0&tabs=visual-studio#remove-obsolete-package-references).

In addition to package upgrades, there was a comment in the Correlation ID middleware that there was a bug in .NET Core 2.1 that the Correlation ID was replaced with a null value with a statement to re-add the Correlation ID as a work-around.  Upon testing, I cannot reproduce this issue in .NET 6, so I have removed this statement.  I have also added an integration test to test for my understanding of the issue, which will fail should the issue re-occur.  Further integration tests have been added for the Correlation ID middleware for full test coverage of the middleware.

####🤔 Why

Packages updates have been requested for .NET and Java Stacks as part of the latest Stacks cycle.

#### 🛠 How

* Simple package updates in the Amido.Stacks.API.csproj file.
* The Push Property for CorrelationID to LogContext has been removed in the CorrelationID middleware and Integration Tests included to test for the previous issue, which I cannot reproduce.

#### 👀 Evidence

* See the Amido.Stacks.API.csproj for version update.
* Passing tests which test for the previous correlation ID issue.

#### 🕵️ How to test

Notes for QA

✅ Acceptance criteria Checklist
Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest change